### PR TITLE
Enhancement/40 file visualizer backend connection

### DIFF
--- a/go-backend/Handlers.go
+++ b/go-backend/Handlers.go
@@ -4,12 +4,30 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
 	"github.com/gorilla/mux"
+    "math/rand"
 )
  
 func Index(w http.ResponseWriter, r *http.Request) {
     fmt.Fprintln(w, "Welcome to Mikaels cool API!")
+}
+
+func Matrix(w http.ResponseWriter, r *http.Request) {
+    mtrx := [100][100]float32{}
+    n := len(mtrx)
+    m := len(mtrx[0])
+    for i := 0; i < n; i++ {
+        for j := 0; j < m; j++ {
+            mtrx[i][j] = rand.Float32()
+        }
+    }
+    w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+    w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.WriteHeader(http.StatusOK)
+ 
+    if err := json.NewEncoder(w).Encode(mtrx); err != nil {
+        panic(err)
+    }
 }
  
 func MessageList(w http.ResponseWriter, r *http.Request) {

--- a/go-backend/Routes.go
+++ b/go-backend/Routes.go
@@ -37,6 +37,12 @@ var routes = Routes{
         Index,
     },
     Route{
+        "Matrix",
+        "GET",
+        "/matrix",
+        Matrix,
+    },
+    Route{
         "MessageList",
         "GET",
         "/messages",

--- a/user-application/README.md~
+++ b/user-application/README.md~
@@ -1,0 +1,20 @@
+## Installation
+
+This project is created with `npx create-react-app 'project-name'`
+https://reactjs.org/ 
+
+To run a test server, make sure you have Node.js and npm on your device
+https://nodejs.org/en/
+
+After repo is cloned, first navigate to `user-application`.
+
+Install requisites with `npm install` in the VSCode terminal.
+Run server with `npm start` in the VSCode integrated terminal.
+If you only want to start the front-end, use `npm run website`.
+To connect the backend, start a new terminal of your choice and navigate to \sahlest-emilsjol-nodelius-project\go-backend and enter `go run .` in your terminal.
+
+If you're on windows, you can accomplish both at the same time by running `npm run windows` while in the user-application directory.
+
+The page will reload if you make edits.
+
+To exit, use `ctrl + c` in both terminals.

--- a/user-application/package.json~
+++ b/user-application/package.json~
@@ -1,0 +1,45 @@
+{
+  "name": "user-application",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@testing-library/jest-dom": "^5.11.10",
+    "@testing-library/react": "^11.2.6",
+    "@testing-library/user-event": "^12.8.3",
+    "mathjs": "^9.3.2",
+    "p5": "^1.3.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-dropzone": "^11.3.2",
+    "react-p5": "^1.3.19",
+    "react-router-dom": "^5.2.0",
+    "react-scripts": "4.0.3",
+    "web-vitals": "^1.1.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "server": "go run server.go",
+    "windows": "server.bat && react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/user-application/src/App.js
+++ b/user-application/src/App.js
@@ -19,8 +19,8 @@ function App() {
     console.log("we wqill now call the server 8080")
     fetch("http://localhost:8080/messages", {
     })
-    .then(response => response.json())
-    .then(data => console.log(data));
+    .then(response => response.json());
+    //.then(data => console.log(data));
   }
 
   return (

--- a/user-application/src/components/AudioAnalyser/AudioVisualiser.js
+++ b/user-application/src/components/AudioAnalyser/AudioVisualiser.js
@@ -14,7 +14,7 @@ class AudioVisualiser extends Component {
         const width = canvas1.width;
         const context = canvas1.getContext('2d');
         const sliceWidth = (width * 2.0)/frequencyData.length;
-        const upperLimit = 2500;
+        const upperLimit = 5;
 
         context.clearRect(0, 0, width, height);
 

--- a/user-application/src/components/UI/Canvas.js
+++ b/user-application/src/components/UI/Canvas.js
@@ -23,6 +23,10 @@ const Canvas = (props) => {
     return mtrx;
   }
 
+  function generateMatrixFromJson(data) {
+    console.log(data);
+  }
+
   const drawRect = (ctx, pos, width, height) => {
     ctx.fillStyle = "#000000";
     ctx.beginPath();
@@ -53,7 +57,9 @@ const Canvas = (props) => {
     let frameCount = 0;
     let animationFrameId;
     //matrisgenererandet behöver vara här för att följa storleken på canvas
+    getInfoFromGoBackend()
     let mtrx = generateMatrix(10, 10, context);
+    
     const render = () => {
       if (runAnimation) {
         setTimeout(() => {
@@ -70,6 +76,13 @@ const Canvas = (props) => {
     };
   }, [animation, runAnimation, framesPerSecond]);
 
+  const getInfoFromGoBackend = () => {
+    console.log("attempting to get matrix from back-end")
+    fetch("http://localhost:8080/matrix", {
+    })
+    .then(response => response.json())
+    .then(data => generateMatrixFromJson(data));
+  }
   return <canvas ref={canvasRef} width="1200" height="650" {...props} />;
 };
 

--- a/user-application/src/components/UI/Canvas.js
+++ b/user-application/src/components/UI/Canvas.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, } from "react";
+import React, { useRef, useEffect, useState, } from "react";
 
 /*
 This component draws a canvas using html canvas tag.
@@ -9,7 +9,8 @@ const Canvas = (props) => {
   const canvasRef = useRef(null);
   const mtrxRef = useRef(0);
   let framesPerSecond = 5;
-  let runAnimation = false;
+  // let runAnimation = false;
+  const [runAnimation, runAnimationSetstate] = useState(false)
 
   function generateMatrixFromJson(data) {
     let mtrx = [];
@@ -49,7 +50,7 @@ const Canvas = (props) => {
       fetch("http://localhost:8080/matrix")
         .then(response => response.json())
         .then(data => generateMatrixFromJson(data))
-        .finally(runAnimation = true)
+        .finally(runAnimationSetstate(true))
         .catch(error => alert(error));
 
   }, []); // <--

--- a/user-application/src/components/UI/Canvas.js
+++ b/user-application/src/components/UI/Canvas.js
@@ -10,8 +10,6 @@ const Canvas = (props) => {
   let framesPerSecond = 5;
   let runAnimation = true;
 
-  //Läste i en tutorial att det är bättre att skriva 'let arry = [];' än 'let arry = new Array(x);'
-  //Tänk att den här matrisen är fft-datan från backend
   function generateMatrix(n, m, ctx) {
     let mtrx = [];
     for (let i = 0; i < n; i++) {
@@ -24,7 +22,15 @@ const Canvas = (props) => {
   }
 
   function generateMatrixFromJson(data) {
-    console.log(data);
+    //console.log(data);
+    let mtrx = [];
+    for (let i = 0; i < data.length; i++) {
+      mtrx[i] = [];
+      for (let j = 0; j < data[i].length; j++) {
+        mtrx[i][j] = data[i][j];
+      }
+    }
+    return mtrx;
   }
 
   const drawRect = (ctx, pos, width, height) => {
@@ -43,23 +49,32 @@ const Canvas = (props) => {
   }
   
   //ogillar att mtrx måste tas som argument men behövs för att längden på staplarna ska följa canvas-storleken
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const animation = (ctx, frameCount, mtrx) => {
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
     drawArray(ctx, frameCount, mtrx);
   };
 
+  
+  
   //körs varje gång animation, runAnimation eller framesPerSecond ändras
   //uppdaterar alltså sig själv vilket leder till animeringen
   useEffect(() => {
     const canvas = canvasRef.current;
     const context = canvas.getContext("2d");
+    let matrixGotten = false;
     let frameCount = 0;
     let animationFrameId;
-    //matrisgenererandet behöver vara här för att följa storleken på canvas
-    getInfoFromGoBackend()
+    //placeholder matris
     let mtrx = generateMatrix(10, 10, context);
     
+    if (matrixGotten == false) {
+      mtrx = getMatrixFromGoBackend();
+      // varför är den här fel format???? den är response?????
+      console.log("matris från getMatrixFromGoBackend(): ");
+      console.log(mtrx);
+      matrixGotten = true;
+    }
+
     const render = () => {
       if (runAnimation) {
         setTimeout(() => {
@@ -76,13 +91,26 @@ const Canvas = (props) => {
     };
   }, [animation, runAnimation, framesPerSecond]);
 
-  const getInfoFromGoBackend = () => {
+  async function getMatrixFromGoBackend() {
     console.log("attempting to get matrix from back-end")
-    fetch("http://localhost:8080/matrix", {
+    let response = await fetch("http://localhost:8080/matrix");
+    if (response.ok) {
+      console.log("reponse ok");
+      let data = await response.json();
+      // den är rätt format här??? vad händer???
+      console.log("generateMatrixFromJson(data) som returnas i getMatrixFromGoBackend():");
+      console.log(generateMatrixFromJson(data));
+      return generateMatrixFromJson(data);
+    } else {
+      alert("HTTP-Error: no response when fetching matrix");
+    }
+    return;
+    /*fetch("http://localhost:8080/matrix", {
     })
     .then(response => response.json())
-    .then(data => generateMatrixFromJson(data));
+    .then(data => generateMatrixFromJson(data));*/
   }
+
   return <canvas ref={canvasRef} width="1200" height="650" {...props} />;
 };
 

--- a/user-application/src/components/UI/Canvas.js
+++ b/user-application/src/components/UI/Canvas.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState, } from "react";
+import React, { useRef, useEffect, useState } from "react";
 
 /*
 This component draws a canvas using html canvas tag.
@@ -10,7 +10,7 @@ const Canvas = (props) => {
   const mtrxRef = useRef(0);
   let framesPerSecond = 5;
   // let runAnimation = false;
-  const [runAnimation, runAnimationSetstate] = useState(false)
+  const [runAnimation, runAnimationSetstate] = useState(false);
 
   function generateMatrixFromJson(data) {
     let mtrx = [];
@@ -23,40 +23,21 @@ const Canvas = (props) => {
     mtrxRef.current = mtrx;
   }
 
-  const drawRect = (ctx, pos, width, height) => {
-    ctx.fillStyle = "#000000";
-    ctx.beginPath();
-    ctx.rect(pos, ctx.canvas.height, width, -height);
-    ctx.fill();
-  };
 
-  const drawArray = (ctx, frameCount, mtrx) => {
-    let currentRow = frameCount % mtrx.length;
-    let width = ctx.canvas.width / mtrx[currentRow].length;
-    for(const [i, barHeight] of mtrx[currentRow].entries()){
-      drawRect(ctx, i*width, width, barHeight * 650)
-    }
-  }
-  
-  //ogillar att mtrx måste tas som argument men behövs för att längden på staplarna ska följa canvas-storleken
-  const animation = (ctx, frameCount, mtrx) => {
-    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-    drawArray(ctx, frameCount, mtrx);
-  };
-  
   //sker en gång, notera tomma klamrarna i slutet
   useEffect(() => {
-
-      fetch("http://localhost:8080/matrix")
-        .then(response => response.json())
-        .then(data => generateMatrixFromJson(data))
-        .finally(runAnimationSetstate(true))
-        .catch(error => alert(error));
-
+    fetch("http://localhost:8080/matrix")
+      .then((response) => response.json())
+      .then((data) => generateMatrixFromJson(data))
+      .finally(runAnimationSetstate(true))
+      .catch((error) => alert(error));
   }, []); // <--
 
   //för säkerhets skull
-  let mtrxTemp = [[1, 1], [1, 1]];
+  let mtrxTemp = [
+    [1, 1],
+    [1, 1],
+  ];
   mtrxRef.current = mtrxTemp;
 
   //körs varje gång animation, runAnimation eller framesPerSecond ändras
@@ -67,6 +48,28 @@ const Canvas = (props) => {
     const context = canvas.getContext("2d");
     let frameCount = 0;
     let animationFrameId;
+
+    //ogillar att mtrx måste tas som argument men behövs för att längden på staplarna ska följa canvas-storleken
+    const animation = (ctx, frameCount, mtrx) => {
+      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+      drawArray(ctx, frameCount, mtrx);
+    };
+
+
+  const drawRect = (ctx, pos, width, height) => {
+    ctx.fillStyle = "#000000";
+    ctx.beginPath();
+    ctx.rect(pos, ctx.canvas.height, width, -height);
+    ctx.fill();
+  };
+
+  const drawArray = (ctx, frameCount, mtrx) => {
+    let currentRow = frameCount % mtrx.length;
+    let width = ctx.canvas.width / mtrx[currentRow].length;
+    for (const [i, barHeight] of mtrx[currentRow].entries()) {
+      drawRect(ctx, i * width, width, barHeight * 650);
+    }
+  };
 
     const render = () => {
       if (runAnimation) {
@@ -82,7 +85,7 @@ const Canvas = (props) => {
     return () => {
       window.cancelAnimationFrame(animationFrameId);
     };
-  }, [animation, runAnimation, framesPerSecond]); // <-- icke-tomma klamrar
+  }, [runAnimation, framesPerSecond]); // <-- icke-tomma klamrar
 
   return <canvas ref={canvasRef} width="1200" height="650" {...props} />;
 };

--- a/user-application/src/components/UI/Canvas.js
+++ b/user-application/src/components/UI/Canvas.js
@@ -36,13 +36,6 @@ const Canvas = (props) => {
       .catch((error) => alert(error));
   }, []); // <--
 
-  //för säkerhets skull
-  let mtrxTemp = [
-    [1, 1],
-    [1, 1],
-  ];
-  mtrxRef.current = mtrxTemp;
-
   /**
    * Animation method to rerender the canvas 
    */

--- a/user-application/src/components/UI/Canvas.js
+++ b/user-application/src/components/UI/Canvas.js
@@ -1,8 +1,9 @@
 import React, { useRef, useEffect, useState } from "react";
 
-/*
-This component draws a canvas using html canvas tag.
-It's based on this article:  https://medium.com/@pdx.lucasm/canvas-with-react-js-32e133c05258#_=_
+/** 
+ * This component draws a canvas using html canvas tag. 
+ * It's based on this article:  https://medium.com/@pdx.lucasm/canvas-with-react-js-32e133c05258#_=_ 
+ * 
 */
 
 const Canvas = (props) => {
@@ -24,7 +25,9 @@ const Canvas = (props) => {
   }
 
 
-  //sker en gång, notera tomma klamrarna i slutet
+  /**
+   * Fetch function when component mounts
+   */
   useEffect(() => {
     fetch("http://localhost:8080/matrix")
       .then((response) => response.json())
@@ -40,16 +43,15 @@ const Canvas = (props) => {
   ];
   mtrxRef.current = mtrxTemp;
 
-  //körs varje gång animation, runAnimation eller framesPerSecond ändras
-  //uppdaterar alltså sig själv vilket leder till animeringen
-  //notera icke-tomma klamrar i slutet
+  /**
+   * Animation method to rerender the canvas 
+   */
   useEffect(() => {
     const canvas = canvasRef.current;
     const context = canvas.getContext("2d");
     let frameCount = 0;
     let animationFrameId;
 
-    //ogillar att mtrx måste tas som argument men behövs för att längden på staplarna ska följa canvas-storleken
     const animation = (ctx, frameCount, mtrx) => {
       ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
       drawArray(ctx, frameCount, mtrx);


### PR DESCRIPTION
#40 
Istället för att Canvas.js visualiserar en lokalt genererad matris får den istället en matris från go-backend att visualisera.
Nu kan man bara plugga in en mer intressant matris i go-backenden så kan den visualiseras.
Krävs att front-end och back-end är igång för att kunna testa funktionalitetn, annars är det bara en svart ruta.